### PR TITLE
docs: romoving Azure Data Studio

### DIFF
--- a/winget.ps1
+++ b/winget.ps1
@@ -17,7 +17,6 @@ $packages = @(
     "JanDeDobbeleer.OhMyPosh",
     "Postman.Postman",
     "Zoom.Zoom.EXE",
-    "Microsoft.AzureDataStudio",
     "Telegram.TelegramDesktop",
     "Insomnia.Insomnia",
     "DevToys-app.DevToys",


### PR DESCRIPTION
This pull request makes a minor update to the `winget.ps1` script by removing the `Microsoft.AzureDataStudio` package from the `$packages` list.